### PR TITLE
Serializer Implementation

### DIFF
--- a/src/api/Data.test.ts
+++ b/src/api/Data.test.ts
@@ -1,8 +1,16 @@
 import { expect, test } from "bun:test";
 import { Property, deserialize, serialize } from "./Data";
 
+export function testSerialization<T>(obj: T, data: any, ctor: Constructor<T>) {
+  const ser = serialize(obj);
+  expect(ser).toEqual(data);
+
+  const res = deserialize(ser, ctor);
+  expect(res).toEqual(obj);
+}
+
 class TestClass {
-  @Property
+  @Property()
   foo: number = 0;
   bar: number = 0;
 
@@ -16,10 +24,32 @@ test("serializes objects from class", () => {
   testObj.foo = 5;
   testObj.load();
 
-  const data = serialize(testObj);
-  expect(data).toEqual({ foo: 5 });
+  const data = { foo: 5 };
 
-  const res = deserialize(data, TestClass);
-  res.load();
-  expect(res).toEqual(testObj);
+  testSerialization(testObj, data, TestClass);
+});
+
+class TestWrapper {
+  @Property(TestClass)
+  data: TestClass;
+  foo: number;
+  bar: number;
+
+  load() {
+    this.foo = this.data.foo;
+    this.bar = this.data.bar;
+  }
+}
+
+test("serialize nested objects", () => {
+  const testObj = new TestClass();
+  testObj.foo = 5;
+  testObj.load();
+
+  const testWrapper = new TestWrapper();
+  testWrapper.data = testObj;
+  testWrapper.load();
+
+  const data = { data: { foo: 5 } };
+  testSerialization(testWrapper, data, TestWrapper);
 });

--- a/src/api/Data.test.ts
+++ b/src/api/Data.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { Property, deserialize, serialize } from "./Data";
+import { Constructor, Property, deserialize, serialize } from "./Data";
+import { Loadable } from "./Util";
 
 export function testSerialization<T>(obj: T, data: any, ctor: Constructor<T>) {
   const ser = serialize(obj);
@@ -9,7 +10,7 @@ export function testSerialization<T>(obj: T, data: any, ctor: Constructor<T>) {
   expect(res).toEqual(obj);
 }
 
-class TestClass {
+class TestClass implements Loadable {
   @Property()
   foo: number = 0;
   bar: number = 0;
@@ -29,15 +30,15 @@ test("serializes objects from class", () => {
   testSerialization(testObj, data, TestClass);
 });
 
-class TestWrapper {
+class TestWrapper implements Loadable {
   @Property(TestClass)
-  data: TestClass;
-  foo: number;
-  bar: number;
+  data?: TestClass;
+  foo?: number;
+  bar?: number;
 
   load() {
-    this.foo = this.data.foo;
-    this.bar = this.data.bar;
+    this.foo = this.data?.foo;
+    this.bar = this.data?.bar;
   }
 }
 
@@ -53,3 +54,46 @@ test("serialize nested objects", () => {
   const data = { data: { foo: 5 } };
   testSerialization(testWrapper, data, TestWrapper);
 });
+
+class TestSubclass1 {
+  @Property()
+  foo?: number;
+}
+
+class TestSubclass2 {
+  @Property()
+  bar?: string;
+}
+
+class TestSubclass3 {
+  @Property()
+  baz?: object;
+}
+
+type TestSubclass = TestSubclass1 | TestSubclass2 | TestSubclass3;
+const SubclassTypes = [TestSubclass1, TestSubclass2, TestSubclass3];
+class TestSubclassWrapper {
+  @Property(...SubclassTypes)
+  objs: TestSubclass[] = [];
+}
+
+// test("serialize subclasses", () => {
+//   const obj = new TestSubclassWrapper();
+//   let newSubclass;
+//
+//   newSubclass = new TestSubclass1();
+//   newSubclass.foo = 5;
+//   obj.objs.push(newSubclass);
+//
+//   newSubclass = new TestSubclass2();
+//   newSubclass.bar = "test";
+//   obj.objs.push(newSubclass);
+//
+//   newSubclass = new TestSubclass3();
+//   newSubclass.baz = {
+//     asdf: "asdf",
+//   };
+//   obj.objs.push(newSubclass);
+//
+//   testSerialization(obj, {}, TestSubclassWrapper);
+// });

--- a/src/api/Data.ts
+++ b/src/api/Data.ts
@@ -1,32 +1,62 @@
+import { Optional } from "./Util";
+
 type Constructor<T> = new () => T;
+
+interface Property {
+  ctor?: Constructor<any>;
+}
 
 interface Metadata {
   id?: string;
-  properties: string[];
+  properties: Record<string, Property>;
 }
 
 interface SerializableObject {
   metadata?: Metadata;
 }
 
-function getMetadata(target: SerializableObject): Metadata {
-  if (!target.metadata) target.metadata = { properties: [] };
+function createMetadata(target: SerializableObject): Metadata {
+  return target.metadata ?? (target.metadata = { properties: {} });
+}
+
+function getMetadata(target: any): Optional<Metadata> {
   return target.metadata;
 }
 
-export function Property(target: any, propertyKey: string) {
-  getMetadata(target).properties.push(propertyKey);
+export function Property(ctor?: Constructor<any>) {
+  return (target: any, key: string) => {
+    createMetadata(target).properties[key] = { ctor };
+  };
 }
 
 export function serialize(target: any): any {
-  const properties = getMetadata(target).properties;
+  if (typeof target === "number") return target;
+  if (Array.isArray(target)) return target.map(serialize);
+
+  const properties = getMetadata(target)?.properties;
+  // return raw objects if no serialization metadata
+  if (!properties) return target;
+
   return Object.fromEntries(
-    Object.entries(target).filter(([k]) => properties.includes(k)),
+    Object.entries(target)
+      .filter(([k]) => Object.keys(properties).includes(k))
+      .map(([k, v]) => [k, getMetadata(v) ? serialize(v) : v]),
   );
 }
 
+/*
+ * Deserializes an object from data using the given constructor.
+ * If the field has serialization metadata (i.e. the class definition
+ * contains a Property annotation) the attached constructor will be
+ * used to deserialize the value separately.
+ */
 export function deserialize<T>(data: any, ctor: Constructor<T>): T {
   const obj = new ctor() as any;
-  Object.entries(data).forEach(([k, v]) => (obj[k] = v));
+  const properties = getMetadata(obj)?.properties;
+  Object.entries(data).forEach(([k, v]) => {
+    const ctor = properties?.[k]?.ctor;
+    obj[k] = ctor ? deserialize(v, ctor) : v;
+  });
+  obj?.load();
   return obj as T;
 }

--- a/src/api/Data2.test.ts
+++ b/src/api/Data2.test.ts
@@ -1,0 +1,6 @@
+import { Property } from "./Data";
+
+export class TestSubclass1 {
+  @Property()
+  fizz?: "buzz";
+}

--- a/src/api/Util.ts
+++ b/src/api/Util.ts
@@ -1,4 +1,7 @@
 export type Optional<T> = T | undefined;
+export interface Loadable {
+  load: () => void;
+}
 
 export function construct<K extends string, V>(
   keys: readonly K[],
@@ -12,4 +15,20 @@ export function construct<K extends string, V>(
 
 export function notEmpty<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined;
+}
+
+export function isPrimitive(val: any): boolean {
+  return val !== Object(val);
+}
+
+export function hash(str: string): number {
+  let res = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    res = (res << 5) - res + code;
+    res = res & res;
+  }
+
+  return Math.abs(res);
 }

--- a/src/content/races/elf/Elf.test.ts
+++ b/src/content/races/elf/Elf.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { Sheet } from "../../../dnd/Sheet";
 import { Elf } from "./Elf";
-import { deserialize, serialize } from "../../../api/Data";
+import { testSerialization } from "../../../api/Data.test";
 
 const baseAbilityScores = {
   strength: 8,
@@ -26,9 +26,19 @@ test("create elf", () => {
 
 test("serialize elf", () => {
   const elf = new Elf();
-  const data = serialize(elf);
-  console.log(data);
+  const expected = {
+    traits: [
+      {
+        _id: "KeenSenses",
+      },
+      {
+        _id: "FeyAncestry",
+      },
+      {
+        _id: "Trance",
+      },
+    ],
+  };
 
-  const res = deserialize(data, Elf);
-  console.log(res);
+  testSerialization(elf, expected, Elf);
 });

--- a/src/content/races/elf/Elf.test.ts
+++ b/src/content/races/elf/Elf.test.ts
@@ -1,17 +1,20 @@
 import { expect, test } from "bun:test";
 import { Sheet } from "../../../dnd/Sheet";
 import { Elf } from "./Elf";
+import { deserialize, serialize } from "../../../api/Data";
+
+const baseAbilityScores = {
+  strength: 8,
+  dexterity: 15,
+  constitution: 13,
+  intelligence: 15,
+  wisdom: 12,
+  charisma: 10,
+};
 
 test("create elf", () => {
   const sheet = new Sheet();
-  sheet.baseAbilityScores = {
-    strength: 8,
-    dexterity: 15,
-    constitution: 13,
-    intelligence: 15,
-    wisdom: 12,
-    charisma: 10,
-  };
+  sheet.baseAbilityScores = baseAbilityScores;
   sheet.setRace(new Elf());
   sheet.load();
 
@@ -19,4 +22,13 @@ test("create elf", () => {
   expect(sheet.abilityScores.dexterity).toEqual(
     sheet.baseAbilityScores.dexterity + 2,
   );
+});
+
+test("serialize elf", () => {
+  const elf = new Elf();
+  const data = serialize(elf);
+  console.log(data);
+
+  const res = deserialize(data, Elf);
+  console.log(res);
 });

--- a/src/content/races/elf/Elf.ts
+++ b/src/content/races/elf/Elf.ts
@@ -1,3 +1,4 @@
+import { Property } from "../../../api/Data";
 import { Subscribe } from "../../../api/Event";
 import { LoadModifiersEvent, Race, Trait } from "../../../dnd/Sheet";
 import { Effect, Effects } from "../../../dnd/Stats";
@@ -14,11 +15,9 @@ export class Trance implements Trait {
   //TODO long rest duration 4h
 }
 
-export class Elf extends Race {
-  constructor() {
-    super();
-    this.traits.push(new KeenSenses(), new FeyAncestry(), new Trance());
-  }
+export class Elf implements Race {
+  @Property(KeenSenses, FeyAncestry, Trance)
+  traits: Trait[] = [new KeenSenses(), new FeyAncestry(), new Trance()];
 
   @Subscribe(LoadModifiersEvent)
   loadModifiers(modifiers: Effect[]) {

--- a/src/content/races/elf/Elf.ts
+++ b/src/content/races/elf/Elf.ts
@@ -15,8 +15,10 @@ export class Trance implements Trait {
   //TODO long rest duration 4h
 }
 
+const ElfTraits = [KeenSenses, FeyAncestry, Trance];
+
 export class Elf implements Race {
-  @Property(KeenSenses, FeyAncestry, Trance)
+  @Property(...ElfTraits)
   traits: Trait[] = [new KeenSenses(), new FeyAncestry(), new Trance()];
 
   @Subscribe(LoadModifiersEvent)

--- a/src/content/races/elf/Elf.ts
+++ b/src/content/races/elf/Elf.ts
@@ -23,7 +23,7 @@ export class Elf extends Race {
   @Subscribe(LoadModifiersEvent)
   loadModifiers(modifiers: Effect[]) {
     modifiers.push(
-      Effects.addSkillScore("dexterity", 2),
+      Effects.addAbilityScore("dexterity", 2),
       Effects.addAttribute("speed", 30),
     );
   }

--- a/src/dnd/Sheet.test.ts
+++ b/src/dnd/Sheet.test.ts
@@ -1,6 +1,6 @@
 import { Sheet } from "./Sheet";
 import { expect, test } from "bun:test";
-import { serialize, deserialize } from "../api/Data";
+import { testSerialization } from "../api/Data.test";
 
 const baseAbilityScores = {
   strength: 8,
@@ -34,10 +34,7 @@ test("serialize and deserialize character sheets", () => {
   sheet.baseAbilityScores = baseAbilityScores;
   sheet.load();
 
-  const data = serialize(sheet);
-  expect(data).toEqual({ baseAbilityScores, feats: [] });
+  const data = { baseAbilityScores, feats: [] };
 
-  const deserialized = deserialize(sheet, Sheet);
-  deserialized.load();
-  expect(deserialized).toEqual(sheet);
+  testSerialization(sheet, data, Sheet);
 });

--- a/src/dnd/Sheet.ts
+++ b/src/dnd/Sheet.ts
@@ -14,8 +14,8 @@ export interface Feat {}
 
 export interface Trait {}
 
-export class Race {
-  traits: Trait[] = [];
+export interface Race {
+  traits: Trait[];
 }
 
 // Character Sheet
@@ -101,7 +101,8 @@ export class Sheet extends Emitter {
     this.addListener(feat);
   }
 
-  @Property(Race)
+  // TODO register all races here
+  @Property()
   race?: Race;
 
   setRace(race: Race) {

--- a/src/dnd/Sheet.ts
+++ b/src/dnd/Sheet.ts
@@ -40,7 +40,7 @@ export class Sheet extends Emitter {
     this.loadAttributes();
   }
 
-  @Property
+  @Property()
   baseAbilityScores = construct(Abilities, 0);
   abilityScores = construct(Abilities, 0);
   abilityModifiers = construct(Abilities, 0);
@@ -93,7 +93,7 @@ export class Sheet extends Emitter {
     this.speed = applyEffects(0, this.modifiers, Effects.filter("speed"));
   }
 
-  @Property
+  @Property()
   feats: Feat[] = [];
 
   addFeat(feat: Feat) {
@@ -101,7 +101,7 @@ export class Sheet extends Emitter {
     this.addListener(feat);
   }
 
-  @Property
+  @Property(Race)
   race?: Race;
 
   setRace(race: Race) {


### PR DESCRIPTION
Implements serializer and deserializer for objects. This includes handling arrays and classes. Added tests to demonstrate this feature with the existing Elf race.

Issues
- Order of registering classes with duplicate names matter, as type map can only compare constructor names, then object equality. Ideally this would not be a problem, but this is an edge case. Unfortunately I do not see any immediate work around that isn't more convoluted.
- Handling nested arrays will create issues, but we will cross that bridge when we get there.